### PR TITLE
fix: decouple MONGODB_PORT_NUMBER from internal container port

### DIFF
--- a/compose.database.yml
+++ b/compose.database.yml
@@ -57,7 +57,7 @@ services:
     user: "0"
     environment:
       MONGODB_REPLICA_SET_NAME: ${MONGODB_REPLICA_SET_NAME:-rs0}
-      MONGODB_PORT_NUMBER: ${MONGODB_PORT_NUMBER:-27017}
+      MONGODB_PORT_NUMBER: "27017"
       MONGODB_URI: ${MONGODB_URI:-mongodb://mongodb:27017/?directConnection=true}
       MONGODB_ADVERTISED_HOSTNAME: ${MONGODB_ADVERTISED_HOSTNAME:-mongodb}
     volumes:
@@ -117,7 +117,7 @@ services:
       test:
         - CMD
         - mongosh
-        - "mongodb://${MONGODB_ADVERTISED_HOSTNAME:-mongodb}:${MONGODB_PORT_NUMBER:-27017}/?directConnection=true"
+        - "mongodb://${MONGODB_ADVERTISED_HOSTNAME:-mongodb}:27017/?directConnection=true"
         - --eval
         - '"db.adminCommand(''ping'')"'
       interval: 30s
@@ -125,7 +125,7 @@ services:
       retries: 10
       start_period: 30s
     ports:
-      - "${MONGODB_BIND_IP:-127.0.0.1}:${MONGODB_PORT_NUMBER:-27017}:${MONGODB_PORT_NUMBER:-27017}"
+      - "${MONGODB_BIND_IP:-127.0.0.1}:${MONGODB_PORT_NUMBER:-27017}:27017"
 
   mongodb-exporter:
     image: docker.io/percona/mongodb_exporter:${MONGODB_EXPORTER_VERSION:-0.44.0}


### PR DESCRIPTION
## Problem

Setting `MONGODB_PORT_NUMBER` to a non-default value (e.g. `49335`) in `.env` breaks MongoDB replica set initialization and causes Rocket.Chat to crash on startup.

**Root cause:** `MONGODB_PORT_NUMBER` is used for both the host port **and** the container port in three places:

1. **Port mapping** (line 128): `${MONGODB_PORT_NUMBER}:${MONGODB_PORT_NUMBER}` — maps host:container to the same value
2. **Healthcheck** (line 120): connects to `mongodb:${MONGODB_PORT_NUMBER}` via the Docker network
3. **Init container** (line 60): registers the replica set member at `mongodb:${MONGODB_PORT_NUMBER}`

However, `mongod` is started without a `--port` flag (line 99), so it always listens on port **27017** inside the container. When `MONGODB_PORT_NUMBER` is anything other than `27017`, all three references point to a port nothing is listening on.

## Steps to reproduce

1. Clone the repo and set `MONGODB_PORT_NUMBER=49335` (or any non-default value) in `.env`
2. Run `docker compose -f compose.database.yml -f compose.yml up -d`
3. Check `mongodb-init-container` logs:
   ```
   MongoServerError: No host described in new configuration with
   {version: 1, term: 0} for replica set rs0 maps to this node
   ```
4. Check `rocketchat` logs:
   ```
   MongoTopologyClosedError: Topology is closed
   MongoServerSelectionError: Server selection timed out after 30000 ms
   reason: TopologyDescription { type: 'ReplicaSetNoPrimary', ... }
   ```

## Fix

Hardcode the internal container port to `27017` (matching `mongod`'s default) and keep `MONGODB_PORT_NUMBER` only for the host-side mapping. This is consistent with how `NATS_PORT_NUMBER` already works in this project:

```yaml
ports:
  - "${NATS_BIND_IP:-127.0.0.1}:${NATS_PORT_NUMBER:-4222}:4222"
                                   
```