### PR TITLE
Support running multiple instances on non-default ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,24 @@ When running multiple Rocket.Chat servers, you can configure Traefik to discover
 ```env
 ROCKETCHAT_BACKEND_SERVERS=rocketchat-1:3000,rocketchat-2:3000,rocketchat-3:3000
 ```
+
+---
+
+### Running multiple instances on the same host
+
+If you need to run a second independent Rocket.Chat stack on the same machine alongside an existing deployment, you must override all host ports in your `.env` to avoid conflicts. The minimum set of variables to change:
+
+```env
+# Rocket.Chat host port (default: 3000)
+HOST_PORT=21000
+
+# NATS host port (default: 4222)
+NATS_PORT_NUMBER=21001
+
+# MongoDB — must be consistent across all three variables
+MONGODB_PORT_NUMBER=27018
+MONGODB_URI=mongodb://mongodb:27018/?directConnection=true
+MONGO_URL=mongodb://mongodb:27018/rocketchat?replicaSet=rs0
+```
+
+> **Note:** `MONGODB_PORT_NUMBER` controls the port mongod listens on *inside* the container, not just the host mapping. All three MongoDB variables must reference the same port number or the replica set initialisation will fail.

--- a/compose.database.yml
+++ b/compose.database.yml
@@ -96,7 +96,7 @@ services:
           owner="$(stat -c %u /data/db 2>/dev/null || true)";
           if [ "$$owner" = "$$MONGODB_USER_ID" ]; then
             echo "=====> /data/db ownership OK ($$owner) - starting MongoDB";
-            exec mongod --replSet "$$MONGODB_REPLICA_SET_NAME" --bind_ip_all;
+            exec mongod --replSet "$$MONGODB_REPLICA_SET_NAME" --bind_ip_all --port "$$MONGODB_PORT_NUMBER";
           fi;
           echo "=====> /data/db owner is '$$owner' (expected $$MONGODB_USER_ID), retrying in 5 seconds...";
           sleep 5;

--- a/compose.yml
+++ b/compose.yml
@@ -16,6 +16,7 @@ services:
       OVERWRITE_SETTING_Prometheus_Enabled: true
       OVERWRITE_SETTING_Prometheus_Port: "${METRICS_PORT:-9458}"
       MONGO_URL: ${MONGO_URL:-mongodb://mongodb:27017/rocketchat?replicaSet=rs0}
+      MONGODB_PORT_NUMBER: ${MONGODB_PORT_NUMBER:-27017}
       TRANSPORTER: "${NATS_URL-monolith+nats://nats:4222}"
       INSTANCE_IP: "${INSTANCE_IP:-}"
     # depends_on:
@@ -25,7 +26,7 @@ services:
     command:
       - -c
       - |
-        echo "=====> Waiting for MongoDB (mongodb:27017) to be ready before starting Rocket.Chat...";
+        echo "=====> Waiting for MongoDB (mongodb:${MONGODB_PORT_NUMBER:-27017}) to be ready before starting Rocket.Chat...";
         for i in $(seq 1 60); do
           if nc -z mongodb 27017 >/dev/null 2>&1; then
             echo "=====> MongoDB is up - starting Rocket.Chat";


### PR DESCRIPTION
- Pass --port to mongod via MONGODB_PORT_NUMBER so the daemon listens on the configured port inside the container, not always 27017.
- Update the Rocket.Chat startup probe to check the correct port.
- Document the minimum .env overrides needed to run a second instance alongside an existing default deployment.